### PR TITLE
V2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.1.0] - [30.03.2018]
+
+### Added
+
+- `plasma.emitAndCollect` - emits chemical to all and return collected their feedback
+- `new Plasma({throwOnMissingHandler: true})` - throws Error when missing handler for a chemical
+
+### Fixed
+
+- when using `new Plasma({missingHandlersChemical: ...})` storing chemicals will no longer trigger missing handlers chemical
+
 ## [2.0.0] - [26.11.2017]
 
 **The release contains breaking changes towards v1.x.x**

--- a/README.md
+++ b/README.md
@@ -195,3 +195,41 @@ instance.emit({
   someData: true
 })
 ```
+
+### throw on missing listeners/handlers for a chemical
+
+When emitting a chemical (via the `.emit` method) which has no registered handlers (via the `.on`/`.once` methods) an Error will be thrown
+
+* The missing handlers error chemical will not be thrown when storing chemicals.
+* by default this feature is disabled unless `throwOnMissingHandler` value is set to `true`
+
+```
+var instance  = new Plasma({
+  throwOnMissingHandler: true
+})
+
+instance.emit("chemicalWithNoHandler") // throws Error
+```
+
+### emit and collect results
+
+To wait all feedbacks provided by organelles upon a single chemical emit
+use `emitAndCollect` method
+
+```
+var instance  = new Plasma()
+instance.on('c1', function reaction1 (c, callback) {
+  callback(null, 1)
+})
+instance.on('c1', function reaction2 (c, callback) {
+  callback(null, 2)
+})
+instance.emitAndCollect('c1', function (results) {
+  console.log(results) // [{err: null, data: 1}, {err: null, data: 2}]
+})
+```
+
+___notes___
+
+* order of results is not guaranteed
+* all reactions must use and invoke the callback to respect the control flow

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/outbounder/organic-plasma.git"
+    "url": "git://github.com/node-organic/organic-plasma.git"
   },
   "author": "Boris Filipov",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/outbounder/organic-plasma/issues"
+    "url": "https://github.com/node-organic/organic-plasma/issues"
   },
-  "homepage": "https://github.com/outbounder/organic-plasma",
+  "homepage": "https://github.com/node-organic/organic-plasma",
   "dependencies": {
     "organic": ">= 1.0.0"
   },
@@ -27,5 +27,8 @@
   },
   "engines": {
     "node": ">=4.2.3"
+  },
+  "directories": {
+    "test": "tests"
   }
 }

--- a/tests/emit-and-collect.spec.js
+++ b/tests/emit-and-collect.spec.js
@@ -1,0 +1,17 @@
+describe("plasma emit and collect feature", function(){
+  var Plasma = require("../index")
+  var instance  = new Plasma()
+  it("emit and collect", function () {
+    instance.on('c1', function (c, callback) {
+      expect(c.type).toBe('c1')
+      callback()
+    })
+    instance.on('c1', function (c, callback) {
+      expect(c.type).toBe('c1')
+      callback()
+    })
+    instance.emitAndCollect({type: "c1"}, function (results) {
+      expect(results.length).toBe(2)
+    })
+  })
+})

--- a/tests/throws-on-missing-handler.spec.js
+++ b/tests/throws-on-missing-handler.spec.js
@@ -1,0 +1,23 @@
+describe("plasma throws on missing handler", function(){
+  var Plasma = require("../index")
+  var instance  = new Plasma({
+    throwOnMissingHandler: true
+  })
+  it("throws", function () {
+    try {
+      instance.emit('c1')
+    } catch (err) {
+      expect(err).toBeDefined()
+      return
+    }
+    throw new Error('shouldnt reach here')
+  })
+  it("doesnt throws on store", function () {
+    try {
+      instance.store('c1')
+    } catch (err) {
+      throw err
+    }
+    expect(instance.get({type:'c1'})).toBeDefined()
+  })
+})


### PR DESCRIPTION
### Added

- `plasma.emitAndCollect` - emits chemical to all and return collected their feedback
- `new Plasma({throwOnMissingHandler: true})` - throws Error when missing handler for a chemical

### Fixed

- when using `new Plasma({missingHandlersChemical: ...})` storing chemicals will no longer trigger missing handlers chemical